### PR TITLE
The problem: sender is wrong sometimes.

### DIFF
--- a/src/DynamoCore/UI/LibraryWrapPanel.cs
+++ b/src/DynamoCore/UI/LibraryWrapPanel.cs
@@ -19,7 +19,8 @@ namespace Dynamo.Controls
         private ObservableCollection<BrowserItem> collection;
         private BrowserInternalElement currentClass;
 
-        public static BrowserInternalElement SelectedItem;
+        //Item, that must be clicked be user.
+        public static BrowserInternalElement AssumedItem;
 
         protected override void OnInitialized(EventArgs e)
         {
@@ -105,13 +106,14 @@ namespace Dynamo.Controls
         {
             var index = ((sender as ListView).SelectedIndex);
             int classInfoIndex = GetClassInformationIndex();
-;
-            //Something went wrong, they must be the same.
-            if ((SelectedItem != (sender as ListView).SelectedItem) && (SelectedItem != null))
+
+            // Something went wrong, AssumedItem and SelectedItem must be the same.
+            // It occurs sometimes, when button,under selected button, was clicked. 
+            if ((AssumedItem != null) && (AssumedItem != (sender as ListView).SelectedItem))
             {
                 foreach (var item in collection)
                 {
-                    if (item as BrowserInternalElement == SelectedItem)
+                    if (item as BrowserInternalElement == AssumedItem)
                     {
                         index = collection.IndexOf(item);
                         (sender as ListView).SelectedIndex = index;

--- a/src/DynamoCore/UI/Views/LibraryView.xaml.cs
+++ b/src/DynamoCore/UI/Views/LibraryView.xaml.cs
@@ -28,7 +28,7 @@ namespace Dynamo.UI.Views
             var classButton = sender as ListViewItem;
             if ((classButton == null) || !classButton.IsSelected)
             {
-                LibraryWrapPanel.SelectedItem = classButton.Content as BrowserInternalElement;
+                LibraryWrapPanel.AssumedItem = classButton.Content as BrowserInternalElement;
                 return;
             }
 


### PR DESCRIPTION
# Bug

[MAGN-4689](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-4689) DUI: Sometimes the math list is not highlighted when the list under math is open
![image](https://cloud.githubusercontent.com/assets/8158404/4334416/b05c749c-3fee-11e4-9782-2fe791afe3fa.png)
Steps to reproduce:
1. Click Color.
2. Click Formula.
3. Make this several times, at 2nd or 3rd it will be broken.
The same thing occurs sometimes with every item and item directly under it.
Catch this bug during debugging is impossible. if put breakpoint inside `OnClassViewSelectionChanged` everything will work correctly... allways.
# Reason

Problem is that `sender` in `OnClassViewSelectionChanged` is wrong.
# Solution

It seems it's time for Workaround.
When classButton is clicked, I save its' Content as `static BrowserInternalElement SelectedItem` and then check whether sender equals to it or not.
# Reviewers

@vmoyseenko, please take a look.
